### PR TITLE
fixed rest-client vul. ver.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,8 @@ gem 'braintree'
 gem 'http'
 
 # Cloudinary photo upload
-gem 'cloudinary'
+# Note: to await new release to avoid rest-client vulnerability
+gem 'cloudinary', '~> 1.9.1'
 
 # END
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,10 +68,9 @@ GEM
       mime-types (>= 1.16)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
-    cloudinary (1.10.0)
+    cloudinary (1.9.1)
       aws_cf_signer
-      json (~> 1.8)
-      rest-client (< 2.0)
+      rest-client
     coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -136,7 +135,6 @@ GEM
     jbuilder (2.8.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
-    json (1.8.6)
     kaminari (1.1.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.1.1)
@@ -173,6 +171,7 @@ GEM
     msgpack (1.2.4)
     multi_json (1.13.1)
     nenv (0.3.0)
+    netrc (0.11.0)
     nio4r (2.3.1)
     nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
@@ -225,8 +224,10 @@ GEM
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     regexp_parser (1.3.0)
-    rest-client (1.6.7)
-      mime-types (>= 1.16)
+    rest-client (2.0.2)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -315,7 +316,7 @@ DEPENDENCIES
   byebug
   capybara
   carrierwave
-  cloudinary
+  cloudinary (~> 1.9.1)
   coffee-rails (~> 4.2)
   database_cleaner
   factory_bot_rails


### PR DESCRIPTION
Temporary fix with using cloudinary version 1.9.1 instead of 1.10.0 due to:
1.  dependency on rest-client <= 1.8.0 vulnerability
2. heroku key error with key not found :cipher for rest-client < 2.0.1

Awaiting fix from cloudinary gem for rest-client dependency >= 2.0.1